### PR TITLE
feat: validate quest on chest open and extend quest content

### DIFF
--- a/src/QuestEngine.Api/Program.cs
+++ b/src/QuestEngine.Api/Program.cs
@@ -62,17 +62,30 @@ app.MapGet("/v1/quests/{questId}/state", async ([FromRoute] string questId, Http
 app.MapPost("/v1/quests/{questId}/choice", async ([FromRoute] string questId, [FromBody] ChoiceRequest req, HttpContext ctx, IQuestRuntime runtime) =>
 {
     var userId = GetUserId(ctx);
-    var res = await runtime.ApplyChoiceAsync(userId, questId, req);
-    return Results.Ok(res);
+    try
+    {
+        var res = await runtime.ApplyChoiceAsync(userId, questId, req);
+        return Results.Ok(res);
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
 });
 
-app.MapPost("/v1/chests/{chestInstanceId}/open", async ([FromRoute] string chestInstanceId, HttpContext ctx, IChestService svc) =>
+app.MapPost("/v1/quests/{questId}/chests/{chestInstanceId}/open", async ([FromRoute] string questId, [FromRoute] string chestInstanceId, HttpContext ctx, IChestService svc) =>
 {
     var userId = GetUserId(ctx);
-    var questId = ctx.Request.Query["questId"].ToString();
     var idem = ctx.Request.Headers["Idempotency-Key"].ToString();
-    var res = await svc.OpenAsync(userId, questId, chestInstanceId, string.IsNullOrEmpty(idem) ? null : idem);
-    return Results.Ok(res);
+    try
+    {
+        var res = await svc.OpenAsync(userId, questId, chestInstanceId, string.IsNullOrEmpty(idem) ? null : idem);
+        return Results.Ok(res);
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
 });
 
 app.Run();

--- a/src/QuestEngine.Api/content/mostbet_odyssey_v1.json
+++ b/src/QuestEngine.Api/content/mostbet_odyssey_v1.json
@@ -99,6 +99,13 @@
           }
         ]
       }
+    },
+    "chest.day3.carnival": {
+      "title": "Сундук Карнавала",
+      "desc": "Награда за испытание",
+      "art": "cdn://ui/chests/carnival.png",
+      "use_pool": "pool.training.fs",
+      "overrides": null
     }
   },
   "stages": [
@@ -235,6 +242,142 @@
       "connect": {
         "next_stage_key": "stage3"
       }
+    }
+    ,
+    {
+      "key": "stage3",
+      "title": "Карнавал Иллюзий",
+      "entry_cards": [
+        { "id": "s3_start", "art": "cdn://art/carnival.png", "cta": "Войти" }
+      ],
+      "scenes": [
+        {
+          "id": "s3_start",
+          "text": "В зеркалах видишь тень...",
+          "choices": [
+            {
+              "id": "accept",
+              "label": "Принять испытание",
+              "effects": [ { "type": "spawn_chest", "chest_id": "chest.day3.carnival" } ],
+              "next": "s3_result"
+            }
+          ]
+        },
+        {
+          "id": "s3_result",
+          "text": "Локи исчезает, напоминая о ценности потерь.",
+          "choices": [],
+          "rewards_on_complete": [
+            { "type": "item", "id": "fragment_3", "amount": 1,
+              "ui": { "title": "Осколок Принятия", "desc": "3/7" } }
+          ]
+        }
+      ],
+      "connect": { "next_stage_key": "stage4" }
+    },
+    {
+      "key": "stage4",
+      "title": "Путь к Центру",
+      "entry_cards": [
+        { "id": "s4_start", "art": "cdn://art/path.png", "cta": "Дальше" }
+      ],
+      "scenes": [
+        {
+          "id": "s4_start",
+          "text": "Путешествие продолжается.",
+          "choices": [
+            { "id": "cont", "label": "Вперед", "effects": [], "next": "s4_end" }
+          ]
+        },
+        {
+          "id": "s4_end",
+          "text": "День завершается.",
+          "choices": [],
+          "rewards_on_complete": [
+            { "type": "item", "id": "fragment_4", "amount": 1,
+              "ui": { "title": "Осколок Пути", "desc": "4/7" } }
+          ]
+        }
+      ],
+      "connect": { "next_stage_key": "stage5" }
+    },
+    {
+      "key": "stage5",
+      "title": "Шторм Удачи",
+      "entry_cards": [
+        { "id": "s5_start", "art": "cdn://art/storm.png", "cta": "Продолжить" }
+      ],
+      "scenes": [
+        {
+          "id": "s5_start",
+          "text": "Новый день приносит испытания.",
+          "choices": [
+            { "id": "cont", "label": "Дальше", "effects": [], "next": "s5_end" }
+          ]
+        },
+        {
+          "id": "s5_end",
+          "text": "Ты проходишь через бурю.",
+          "choices": [],
+          "rewards_on_complete": [
+            { "type": "item", "id": "fragment_5", "amount": 1,
+              "ui": { "title": "Осколок Стойкости", "desc": "5/7" } }
+          ]
+        }
+      ],
+      "connect": { "next_stage_key": "stage6" }
+    },
+    {
+      "key": "stage6",
+      "title": "Древо Решений",
+      "entry_cards": [
+        { "id": "s6_start", "art": "cdn://art/tree.png", "cta": "Подойти" }
+      ],
+      "scenes": [
+        {
+          "id": "s6_start",
+          "text": "Гигантское дерево с ветвями из света.",
+          "choices": [
+            { "id": "observe", "label": "Взглянуть на плоды", "effects": [], "next": "s6_end" }
+          ]
+        },
+        {
+          "id": "s6_end",
+          "text": "Друид даёт наставление о твоём пути.",
+          "choices": [],
+          "rewards_on_complete": [
+            { "type": "item", "id": "fragment_6", "amount": 1,
+              "ui": { "title": "Осколок Роста", "desc": "6/7" } }
+          ]
+        }
+      ],
+      "connect": { "next_stage_key": "stage7" }
+    },
+    {
+      "key": "stage7",
+      "title": "Финальное Испытание",
+      "entry_cards": [
+        { "id": "s7_start", "art": "cdn://art/final.png", "cta": "В портал" }
+      ],
+      "scenes": [
+        {
+          "id": "s7_start",
+          "text": "Шесть осколков резонируют, открывая портал.",
+          "choices": [
+            { "id": "finish", "label": "Сделать выбор", "effects": [], "next": "s7_end" }
+          ]
+        },
+        {
+          "id": "s7_end",
+          "text": "Битва с Бездной завершается твоей победой.",
+          "choices": [],
+          "rewards_on_complete": [
+            { "type": "item", "id": "fragment_7", "amount": 1,
+              "ui": { "title": "Последний Осколок", "desc": "7/7" } }
+          ]
+        }
+      ],
+      "connect": { }
     }
   ]
 }

--- a/src/QuestEngine.Application/Implementations.cs
+++ b/src/QuestEngine.Application/Implementations.cs
@@ -145,6 +145,8 @@ public sealed class ChestService : IChestService
     public async Task<ChestOpenResult> OpenAsync(string userId, string questId, string chestInstanceId, string? idemKey)
     {
         var chest = await _store.GetChestAsync(chestInstanceId) ?? throw new InvalidOperationException("Chest not found");
+        if (chest.QuestId != questId)
+            throw new InvalidOperationException("Chest not in this quest");
         if (chest.Status == "opened" && chest.ResultSnapshot is ChestOpenResult prev) return prev;
 
         // restore pool


### PR DESCRIPTION
## Summary
- return 4xx on invalid choices and chest opens
- ensure chests belong to selected quest
- flesh out 7-day quest data for Наследники Золотого Колеса

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b6a2dd3a08832b975a69f0d0c4153c