### PR TITLE
feat: add stage conditions endpoint

### DIFF
--- a/src/QuestEngine.Api/content/mostbet_odyssey_v1.json
+++ b/src/QuestEngine.Api/content/mostbet_odyssey_v1.json
@@ -191,6 +191,9 @@
     {
       "key": "stage2",
       "title": "Башня Вечно Крутящихся Рун",
+      "conditions": [
+        { "param": "fragment_1", "min": 1 }
+      ],
       "entry_cards": [
         {
           "id": "s2_entrance",
@@ -247,6 +250,9 @@
     {
       "key": "stage3",
       "title": "Карнавал Иллюзий",
+      "conditions": [
+        { "param": "fragment_2", "min": 1 }
+      ],
       "entry_cards": [
         { "id": "s3_start", "art": "cdn://art/carnival.png", "cta": "Войти" }
       ],
@@ -278,6 +284,9 @@
     {
       "key": "stage4",
       "title": "Путь к Центру",
+      "conditions": [
+        { "param": "fragment_3", "min": 1 }
+      ],
       "entry_cards": [
         { "id": "s4_start", "art": "cdn://art/path.png", "cta": "Дальше" }
       ],
@@ -304,6 +313,9 @@
     {
       "key": "stage5",
       "title": "Шторм Удачи",
+      "conditions": [
+        { "param": "fragment_4", "min": 1 }
+      ],
       "entry_cards": [
         { "id": "s5_start", "art": "cdn://art/storm.png", "cta": "Продолжить" }
       ],
@@ -330,6 +342,9 @@
     {
       "key": "stage6",
       "title": "Древо Решений",
+      "conditions": [
+        { "param": "fragment_5", "min": 1 }
+      ],
       "entry_cards": [
         { "id": "s6_start", "art": "cdn://art/tree.png", "cta": "Подойти" }
       ],
@@ -356,6 +371,9 @@
     {
       "key": "stage7",
       "title": "Финальное Испытание",
+      "conditions": [
+        { "param": "fragment_6", "min": 1 }
+      ],
       "entry_cards": [
         { "id": "s7_start", "art": "cdn://art/final.png", "cta": "В портал" }
       ],

--- a/src/QuestEngine.Api/content/mostbet_odyssey_v1.json
+++ b/src/QuestEngine.Api/content/mostbet_odyssey_v1.json
@@ -174,7 +174,7 @@
           "rewards_on_complete": [
             {
               "type": "item",
-              "id": "fragment_1",
+              "id": "golden_wheel_fragment",
               "amount": 1,
               "ui": {
                 "title": "Осколок Начинаний",
@@ -192,7 +192,7 @@
       "key": "stage2",
       "title": "Башня Вечно Крутящихся Рун",
       "conditions": [
-        { "param": "fragment_1", "min": 1 }
+        { "param": "golden_wheel_fragments", "min": 1 }
       ],
       "entry_cards": [
         {
@@ -232,7 +232,7 @@
           "rewards_on_complete": [
             {
               "type": "item",
-              "id": "fragment_2",
+              "id": "golden_wheel_fragment",
               "amount": 1,
               "ui": {
                 "title": "Осколок Мудрости",
@@ -251,7 +251,7 @@
       "key": "stage3",
       "title": "Карнавал Иллюзий",
       "conditions": [
-        { "param": "fragment_2", "min": 1 }
+        { "param": "golden_wheel_fragments", "min": 2 }
       ],
       "entry_cards": [
         { "id": "s3_start", "art": "cdn://art/carnival.png", "cta": "Войти" }
@@ -274,7 +274,7 @@
           "text": "Локи исчезает, напоминая о ценности потерь.",
           "choices": [],
           "rewards_on_complete": [
-            { "type": "item", "id": "fragment_3", "amount": 1,
+            { "type": "item", "id": "golden_wheel_fragment", "amount": 1,
               "ui": { "title": "Осколок Принятия", "desc": "3/7" } }
           ]
         }
@@ -285,7 +285,7 @@
       "key": "stage4",
       "title": "Путь к Центру",
       "conditions": [
-        { "param": "fragment_3", "min": 1 }
+        { "param": "golden_wheel_fragments", "min": 3 }
       ],
       "entry_cards": [
         { "id": "s4_start", "art": "cdn://art/path.png", "cta": "Дальше" }
@@ -303,7 +303,7 @@
           "text": "День завершается.",
           "choices": [],
           "rewards_on_complete": [
-            { "type": "item", "id": "fragment_4", "amount": 1,
+            { "type": "item", "id": "golden_wheel_fragment", "amount": 1,
               "ui": { "title": "Осколок Пути", "desc": "4/7" } }
           ]
         }
@@ -314,7 +314,7 @@
       "key": "stage5",
       "title": "Шторм Удачи",
       "conditions": [
-        { "param": "fragment_4", "min": 1 }
+        { "param": "golden_wheel_fragments", "min": 4 }
       ],
       "entry_cards": [
         { "id": "s5_start", "art": "cdn://art/storm.png", "cta": "Продолжить" }
@@ -332,7 +332,7 @@
           "text": "Ты проходишь через бурю.",
           "choices": [],
           "rewards_on_complete": [
-            { "type": "item", "id": "fragment_5", "amount": 1,
+            { "type": "item", "id": "golden_wheel_fragment", "amount": 1,
               "ui": { "title": "Осколок Стойкости", "desc": "5/7" } }
           ]
         }
@@ -343,7 +343,7 @@
       "key": "stage6",
       "title": "Древо Решений",
       "conditions": [
-        { "param": "fragment_5", "min": 1 }
+        { "param": "golden_wheel_fragments", "min": 5 }
       ],
       "entry_cards": [
         { "id": "s6_start", "art": "cdn://art/tree.png", "cta": "Подойти" }
@@ -361,7 +361,7 @@
           "text": "Друид даёт наставление о твоём пути.",
           "choices": [],
           "rewards_on_complete": [
-            { "type": "item", "id": "fragment_6", "amount": 1,
+            { "type": "item", "id": "golden_wheel_fragment", "amount": 1,
               "ui": { "title": "Осколок Роста", "desc": "6/7" } }
           ]
         }
@@ -372,7 +372,7 @@
       "key": "stage7",
       "title": "Финальное Испытание",
       "conditions": [
-        { "param": "fragment_6", "min": 1 }
+        { "param": "golden_wheel_fragments", "min": 6 }
       ],
       "entry_cards": [
         { "id": "s7_start", "art": "cdn://art/final.png", "cta": "В портал" }
@@ -390,7 +390,7 @@
           "text": "Битва с Бездной завершается твоей победой.",
           "choices": [],
           "rewards_on_complete": [
-            { "type": "item", "id": "fragment_7", "amount": 1,
+            { "type": "item", "id": "golden_wheel_fragment", "amount": 1,
               "ui": { "title": "Последний Осколок", "desc": "7/7" } }
           ]
         }

--- a/src/QuestEngine.Application/Abstractions.cs
+++ b/src/QuestEngine.Application/Abstractions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using QuestEngine.Domain;
 
 namespace QuestEngine.Application;
@@ -45,6 +46,7 @@ public interface IChestService
 public interface IQuestRuntime
 {
     Task<StateResponse> GetStateAsync(string userId, string questId);
+    Task<StateResponse> GetStageAsync(string questId, IDictionary<string,int> parameters);
     Task<ChoiceResponse> ApplyChoiceAsync(string userId, string questId, ChoiceRequest req);
 }
 

--- a/src/QuestEngine.Domain/Models.cs
+++ b/src/QuestEngine.Domain/Models.cs
@@ -60,9 +60,14 @@ public record SceneDef(
 
 public record StageConnect([property: JsonPropertyName("next_stage_key")] string NextStageKey);
 
+public record StageCondition(
+    [property: JsonPropertyName("param")] string Param,
+    [property: JsonPropertyName("min")] int Min);
+
 public record StageDef(
     [property: JsonPropertyName("key")] string Key,
     [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("conditions")] IReadOnlyList<StageCondition>? Conditions,
     [property: JsonPropertyName("entry_cards")] IReadOnlyList<EntryCard> EntryCards,
     [property: JsonPropertyName("scenes")] IReadOnlyList<SceneDef> Scenes,
     [property: JsonPropertyName("connect")] StageConnect Connect);


### PR DESCRIPTION
## Summary
- add conditions to quest stages and new stateless stage resolution
- expose `/v1/quests/{questId}/stages` endpoint that accepts params
- include sample conditions in mostbet_odyssey_v1 content

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bde99774832ba55b1b19deb0f4af